### PR TITLE
A7077A-95 Rename ADI entry field references

### DIFF
--- a/src/example_application/abcc_network_data_parameters.c
+++ b/src/example_application/abcc_network_data_parameters.c
@@ -34,8 +34,8 @@ uint16_t appl_iRefSpeed;
 static AD_UINT16Type appl_sUint16Prop = { { 0, 0xFFFF, 0 } };
 
 /*-------------------------------------------------------------------------------------------------------------
-** 1. iInstance | 2. pacName | 3. bDataType | 4. bNumOfElements | 5. bDesc | 6. pxValuePtr | 7. pxValuePropPtr
-**--------------------------------------------------------------------------------------------------------------
+** 1. iInstance | 2. pacName | 3. bDataType | 4. bNumOfElements | 5. bDesc | 6. pxValuePtr | 7. pxValueProps
+**-------------------------------------------------------------------------------------------------------------
 */
 const AD_AdiEntryType ABCC_API_asAdiEntryList[] =
 {

--- a/src/example_application/abcc_network_data_parameters.c
+++ b/src/example_application/abcc_network_data_parameters.c
@@ -34,7 +34,7 @@ uint16_t appl_iRefSpeed;
 static AD_UINT16Type appl_sUint16Prop = { { 0, 0xFFFF, 0 } };
 
 /*-------------------------------------------------------------------------------------------------------------
-** 1. iInstance | 2. pabName | 3. bDataType | 4. bNumOfElements | 5. bDesc | 6. pxValuePtr | 7. pxValuePropPtr
+** 1. iInstance | 2. pacName | 3. bDataType | 4. bNumOfElements | 5. bDesc | 6. pxValuePtr | 7. pxValuePropPtr
 **--------------------------------------------------------------------------------------------------------------
 */
 const AD_AdiEntryType ABCC_API_asAdiEntryList[] =

--- a/src/example_application/abcc_network_data_parameters.c
+++ b/src/example_application/abcc_network_data_parameters.c
@@ -44,7 +44,7 @@ const AD_AdiEntryType ABCC_API_asAdiEntryList[] =
 };
 
 /*------------------------------------------------------------------------------
-** Map all adi:s in both directions
+** Map all ADI:s in both directions
 **------------------------------------------------------------------------------
 ** 1. AD instance | 2. Direction | 3. Num elements | 4. Start index |
 **------------------------------------------------------------------------------


### PR DESCRIPTION
- pabName → pacName: 'pa' (pointer to byte array) is incorrect for a character string; 'pac' (pointer to array of char) matches the actual type and naming convention used elsewhere.
- pxValuePropPtr → pxValueProps